### PR TITLE
feat: add DeepSource coverage upload to workflow

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -409,7 +409,47 @@ jobs:
           if-no-files-found: warn
 
   # ==============================================================================
-  # 5) Codacy Upload (SARIF + Coverage)
+  # 5) DeepSource Coverage Upload
+  # ==============================================================================
+  DeepSource_Upload:
+    needs: [Sonar_Analysis]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    if: always()
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Download Coverage Reports
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-reports
+          path: coverage-merged
+
+      - name: Upload Coverage to DeepSource
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+        run: |
+          if [ -z "${DEEPSOURCE_DSN:-}" ]; then
+            echo "DEEPSOURCE_DSN not set. Skipping DeepSource upload."
+            exit 0
+          fi
+
+          curl https://deepsource.io/cli | sh
+          
+          if [ -f "coverage-merged/Cobertura.xml" ]; then
+            ./bin/deepsource report --analyzer test-coverage --key csharp --value-file coverage-merged/Cobertura.xml
+          else
+            echo "Cobertura.xml not found. Skipping coverage upload."
+          fi
+
+  # ==============================================================================
+  # 6) Codacy Upload (SARIF + Coverage)
   # ==============================================================================
   Codacy_Upload:
     needs: [ReSharper_Analysis, Snyk_Scan, Semgrep_Scan, Sonar_Analysis]


### PR DESCRIPTION
Adds DeepSource coverage upload step to the Analysis workflow (Publish.yml).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
Adds a new DeepSource Coverage Upload job to the GitHub Actions Analysis workflow that automatically uploads Cobertura coverage reports to DeepSource after successful test execution and analysis completion.

## Changes by Category

### 🔧 Indicators
- Integrates DeepSource CLI for continuous coverage reporting and monitoring
- Downloads merged coverage reports (Cobertura format) from Sonar_Analysis job and uploads to DeepSource platform
- Executes after Sonar_Analysis job completes to ensure coverage data is available

### 🛡️ Robustness
- Includes credential validation via `DEEPSOURCE_DSN` secret check—gracefully skips upload if secret is not configured
- Handles missing coverage files with explicit logging when `Cobertura.xml` is not found instead of failing silently
- Uses `if: always()` condition to ensure upload attempt even if prior jobs have warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->